### PR TITLE
Fix WikiTree CORS in production + rate limit handling (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-03-26
+
+### Added
+- `apiBase` option on `loadWikiTree()` and `loadWikiTreeData()` — supply your own proxy URL to work around WikiTree's CORS restrictions
+- Cloudflare Worker proxy (`cloudflare-worker/wikitree-proxy.js`) — forwards requests to WikiTree, adds CORS headers, caches responses for 5 minutes
+
+### Fixed
+- WikiTree API calls now work from GitHub Pages and any external origin via the Cloudflare Worker proxy
+- HTTP 429 rate limit responses surface as a readable error message rather than a generic failure
+- Dev server routes WikiTree requests through the Vite proxy to avoid CORS errors on localhost
+
+## [1.1.0] - 2026-03-26
+
+### Added
+- `loadWikiTree(id, options?)` method — fetch and render ancestors directly from WikiTree by profile ID, no GEDCOM file needed
+- `depth` option (1–4 generations, default 3) controls how many ancestor generations to retrieve
+- Profile photos displayed in the avatar circle when available from WikiTree (`PhotoData` field)
+- `photoUrl?: string` field on `Individual` type
+- Multi-page GitHub Pages demo site: landing page, GEDCOM demo, WikiTree demo, API docs
+- Cloudflare Worker proxy for WikiTree API CORS (production)
+- Vite dev server proxy for WikiTree API CORS (development)
+
+### Fixed
+- WikiTree loader uses `getPeople` API (replaces deprecated `getAncestors`)
+- Private/permission-denied profiles no longer crash the loader (Id ≤ 0 sentinel entries filtered out)
+- Corrected example WikiTree IDs: `Einstein-1`, `Darwin-15`, `Washington-11`
+
 ## [1.0.0] - 2026-03-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "family-tree-viewer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "./dist/family-tree-viewer.umd.cjs",
   "module": "./dist/family-tree-viewer.js",


### PR DESCRIPTION
Closes #3

## Summary

- **Cloudflare Worker** (`cloudflare-worker/wikitree-proxy.js`) — proxies WikiTree API requests with proper CORS headers and 5-minute response caching to avoid upstream rate limits
- **`apiBase` option** on `loadWikiTree()` / `loadWikiTreeData()` — lets any consumer supply their own proxy URL
- **Demo wiring** — `demo/.env.production` injects the worker URL at build time via `VITE_WIKITREE_PROXY`; dev still uses the Vite server proxy
- **429 handling** — surfaces as a readable error message rather than a generic failure
- **CHANGELOG** — backfilled 1.1.0 entry and added 1.2.0
- **Version bump** — 1.1.0 → 1.2.0

## Test plan

- [x] `npm test` — 90 tests pass
- [x] `npm run typecheck` — clean
- [x] GitHub Pages demo loads `Einstein-1` without CORS errors (via worker)
- [x] `loadWikiTree('Einstein-1', { apiBase: '...' })` routes through supplied URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)